### PR TITLE
Compatibility of terminal summary hook with pytest<4.2

### DIFF
--- a/pytest_mpi/__init__.py
+++ b/pytest_mpi/__init__.py
@@ -60,6 +60,12 @@ class MPIPlugin(object):
             if label in item.keywords:
                 item.add_marker(marker)
 
+    def pytest_configure(self, config):
+        """
+        Hook setting config object (always called at least once)
+        """
+        self._is_testing_mpi = self._testing_mpi(config)
+
     def pytest_collection_modifyitems(self, config, items):
         """
         Skip tests depending on what options are chosen
@@ -80,12 +86,12 @@ class MPIPlugin(object):
                     pytest.mark.skip(reason="need --with-mpi option to run")
                 )
 
-    def pytest_terminal_summary(self, terminalreporter, exitstatus, config):
+    def pytest_terminal_summary(self, terminalreporter, exitstatus, *args):
         """
         Hook for printing MPI info at the end of the run
         """
         # pylint: disable=unused-argument
-        if self._testing_mpi(config):
+        if self._is_testing_mpi:
             terminalreporter.section("MPI Information")
             try:
                 from mpi4py import MPI, rc, get_config

--- a/pytest_mpi/__init__.py
+++ b/pytest_mpi/__init__.py
@@ -44,6 +44,8 @@ class MPIPlugin(object):
     pytest plugin to assist with testing MPI-using code
     """
 
+    _is_testing_mpi = False
+
     def _testing_mpi(self, config):
         """
         Return if we're testing with MPI or not.


### PR DESCRIPTION
Hello!

Pytest 4.2 introduced the `config` argument to
`pytest_terminal_summary`, which is not backwards compatible.

I added a flag that is initialized when the hook `pytest_configure` is called, which is then used in the `pytest_terminal_summary` instead of the previous `config` argument. I tried with versions 3.10.1 and 5.4.2 on a homegrown test and it works. I am unfamiliar with tox, but I think it would be best if several versions of pytest were tested.

Fixes #3 

By the way, the version on pypi is out of date with respect to bugfixes on `min_size` for mpi tests.

Cheers!