### PR TITLE
Fix min_size text output

### DIFF
--- a/pytest_mpi/__init__.py
+++ b/pytest_mpi/__init__.py
@@ -133,7 +133,8 @@ class MPIPlugin(object):
                 if min_size is not None and comm.size < min_size:
                     pytest.skip(
                         "Test requires {} MPI processes, only {} MPI "
-                        "processes specified, skipping test"
+                        "processes specified, skipping "
+                        "test".format(min_size, comm.size)
                     )
 
 


### PR DESCRIPTION
This fixes missing output in when the min_size requirement is not met.

Also, echoing the PR above, the conda-forge release is out of date with the min_size bug fix (and now this).