### PR TITLE
Add note about requiring pytester

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -28,6 +28,10 @@ for more information about tox, but the simplest method is to run::
 
 in the top level of the git repository.
 
+.. note::
+    If you want to run pytest directly, remember to include ``-p pytester``, as
+    pytester needs to be manually activated.
+
 .. _tox: https://tox.readthedocs.io/en/latest/
 
 Making a release


### PR DESCRIPTION
This is in response to #4 (though I realised after I made the 0.4 release that this wasn't included).