### PR TITLE
Use dedicated group for CLI options

### DIFF
--- a/src/pytest_mpi/__init__.py
+++ b/src/pytest_mpi/__init__.py
@@ -241,11 +241,12 @@ def pytest_addoption(parser):
     """
     Add pytest-mpi options to pytest cli
     """
-    parser.addoption(
+    group = parser.getgroup("mpi", description="support for MPI-enabled code")
+    group.addoption(
         WITH_MPI_ARG, action="store_true", default=False,
         help="Run MPI tests, this should be paired with mpirun."
     )
-    parser.addoption(
+    group.addoption(
         ONLY_MPI_ARG, action="store_true", default=False,
         help="Run *only* MPI tests, this should be paired with mpirun."
     )


### PR DESCRIPTION
This provides proper context for the MPI-related options when displaying
the usage information, instead of listing them under 'custom options'.