### PR TITLE
Rebased version of #41

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,3 +37,7 @@ also specify a minimum number of processes required to run the test:
 There are also `mpi_skip`, for when a test should not be run under MPI (e.g. it
 causes a lockup or segmentation fault), and `mpi_xfail`, for when a test should
 succeed when run normally, but fail when run under MPI.
+
+.. note::
+   By default, only the output from rank 0 will be shown in the terminal. To
+   bypass this, pass the option `--unmute-ranks`.

--- a/src/pytest_mpi/__init__.py
+++ b/src/pytest_mpi/__init__.py
@@ -270,5 +270,5 @@ def pytest_addoption(parser):
     )
     group.addoption(
         UNMUTE_NONZERO_RANKS_ARG, action="store_true", default=False,
-        help="Suppress all output from ranks that are not 0."
+        help="Show all output from all ranks, not just zero."
     )

--- a/src/pytest_mpi/__init__.py
+++ b/src/pytest_mpi/__init__.py
@@ -13,6 +13,7 @@ __version__ = _version.get_versions()['version']
 
 WITH_MPI_ARG = "--with-mpi"
 ONLY_MPI_ARG = "--only-mpi"
+UNMUTE_NONZERO_RANKS_ARG = "--unmute-ranks"
 
 
 class MPIMarkerEnum(str, Enum):
@@ -217,6 +218,7 @@ def mpi_tmp_path(tmp_path):
     return Path(name)
 
 
+@pytest.mark.trylast
 def pytest_configure(config):
     """
     Add pytest-mpi to pytest (see pytest docs for more info)
@@ -234,7 +236,23 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "mpi_xfail: Tests that fail when run under MPI/mpirun"
     )
-    config.pluginmanager.register(MPIPlugin())
+    mpi = MPIPlugin()
+    config.pluginmanager.register(mpi)
+
+    # check whether to mute output
+    unmute = config.getoption(UNMUTE_NONZERO_RANKS_ARG)
+    if mpi._is_testing_mpi and not unmute:
+        try:
+            from mpi4py import MPI
+        except ImportError:
+            return
+
+        if MPI.COMM_WORLD.Get_rank() != 0:
+            # unregister the standard reporter for all nonzero ranks
+            standard_reporter = config.pluginmanager.getplugin(
+                'terminalreporter'
+            )
+            config.pluginmanager.unregister(standard_reporter)
 
 
 def pytest_addoption(parser):
@@ -249,4 +267,8 @@ def pytest_addoption(parser):
     group.addoption(
         ONLY_MPI_ARG, action="store_true", default=False,
         help="Run *only* MPI tests, this should be paired with mpirun."
+    )
+    group.addoption(
+        UNMUTE_NONZERO_RANKS_ARG, action="store_true", default=False,
+        help="Suppress all output from ranks that are not 0."
     )


### PR DESCRIPTION
Replaces #41 in that the tests run and pass now. Hopefully this cases no breakage.