### PR TITLE
Port to Sphinx 8.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,4 +185,4 @@ epub_exclude_files = ['search.html']
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/', None)}


### PR DESCRIPTION
The old `intersphinx_mapping` format has been removed; it must now map identifiers to (target, inventory) tuples.